### PR TITLE
Changed travis binstar upload from gaff2xml-dev to gaff2xml 'dev' version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
   - conda install --yes conda-build
   - conda build devtools/conda-recipe
   - source activate $python
-  - conda install $HOME/miniconda/conda-bld/linux-64/gaff2xml-dev-*
+  - conda install $HOME/miniconda/conda-bld/linux-64/gaff2xml-*
   - conda list -e
   - nosetests
 
@@ -21,7 +21,7 @@ env:
 
   global:
     # encrypted BINSTAR_TOKEN for push of dev package to binstar
-    - secure: I/lGWwQgnRX7UuikhyK0PCwRXIyzT5M5hU0ojnNsNBTiTf0CCj4qJK5K+aBI4yrLIKRAF+uHKYEhnIdA3rTi6Mk4FdM9DEecv9+9m2UDbB1mQcuYmimoaHG90lVXXzfP7wsA05JbshOEQPSUocQvmGksN2NyX+lu79NUsOQRaPs=
+    - secure: "gECFor8xpjGG0xmdmy39eGjYBA/xFF/NKjWmp0Hphzn1kwHjVtJJ3DzAsEepr9a9USeti/vLxaI7cWRF95rGo5PzAftY21f6qyhBsBcF3S9twyNof7W6ROoZW+xoRPWdfKLypG/2pkOGOajOgUQALUkA1Ze75E03VuMQ003UgWY="
 
 after_success:
   - echo "after_success"

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ "2.7 3.3" =~ "$python" ]]; then
     conda install --yes binstar
-    binstar -t $BINSTAR_TOKEN  upload --force -u omnia -p gaff2xml-dev $HOME/miniconda/conda-bld/linux-64/gaff2xml-dev-*
+    binstar -t $BINSTAR_TOKEN  upload --force -u omnia -p gaff2xml $HOME/miniconda/conda-bld/linux-64/gaff2xml-*
 fi
 
 if [[ "$python" != "2.7" ]]; then

--- a/devtools/conda-recipe/README.md
+++ b/devtools/conda-recipe/README.md
@@ -1,13 +1,12 @@
-This is a recipe for building the current development package into a conda
-binary.
+This is a recipe for building the current development package into a conda binary.
 
 The installation on travis-ci is done by building the conda package, installing
 it, running the tests, and then if successful pushing the package to binstar
 (and the docs to AWS S3). The binstar auth token is an encrypted environment
 variable generated using:
-
-binstar auth -n gaff2xml-travis -o omnia --max-age 22896000 -c --scopes api:write
-
-and then saved in the environment variable BINSTAR_TOKEN.
+```
+binstar auth -n gaff2xml -o omnia --max-age 22896000 -c --scopes api:write
+```
+and then saved in the environment variable `BINSTAR_TOKEN`.
 
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -10,17 +10,17 @@ requirements:
     - numpy
     - scipy
     - setuptools
-    - mdtraj-dev
-    - openmm    
-    - ambermini    
+    - mdtraj
+    - openmm
+    - ambermini
 
   run:
     - python
     - pandas
     - scipy
-    - mdtraj-dev
-    - openmm    
-    - ambermini    
+    - mdtraj
+    - openmm
+    - ambermini
 
 about:
   home: https://github.com/choderalab/gaff2xml


### PR DESCRIPTION
Instead of having `packagename` and `packagename-dev` versions on binstar, it makes more sense to just have travis upload a package with the `dev` version string to the `packagename`.