### PR TITLE
Switched from hard-coded jenkins / travis detection in tests to nose attribute 'slow'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 env:
   matrix:
     - python=2.7  CONDA_PY=27
-    - python=3.3  CONDA_PY=33
+    - python=3.4  CONDA_PY=34
 
   global:
     # encrypted BINSTAR_TOKEN for push of dev package to binstar

--- a/devtools/ci/install.sh
+++ b/devtools/ci/install.sh
@@ -17,4 +17,4 @@ conda update --yes conda
 conda config --add channels http://conda.binstar.org/omnia
 conda config --add channels https://conda.binstar.org/rdkit
 source activate $python
-conda install --yes conda-build
+conda install --yes conda-build jinja2

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - pandas    
     - openmm
     - ambermini
-    - jinja2
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
   run:
     - python
@@ -32,7 +31,6 @@ requirements:
     - scipy
     - openmm
     - ambermini
-    - jinja2
 #    - rdkit    # rdkit is an optional dependency, may want to comment this out for the release version.
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
-  name: gaff2xml-dev
-  version: !!str 3.0.0
+  name: gaff2xml
+  version: !!str dev
 
 #source:
 #  fn: master.zip
@@ -41,7 +41,7 @@ test:
   imports:
     - gaff2xml
   commands:
-    - nosetests gaff2xml -v
+    - nosetests gaff2xml -v -a '!slow'
 
 about:
   home: https://github.com/choderalab/gaff2xml

--- a/gaff2xml/tests/test_drugs.py
+++ b/gaff2xml/tests/test_drugs.py
@@ -1,3 +1,4 @@
+from nose.plugins.attrib import attr
 from unittest import skipIf
 from gaff2xml import utils
 import os
@@ -17,6 +18,7 @@ except:
 
 
 @skipIf(not HAVE_OE, "Cannot run test_drugs() module without OpenEye tools.")
+@attr('slow')
 def test_drugs():
     import openeye.oechem
     database_filename = utils.get_data_filename("chemicals/drugs/Zdd.mol2.gz")

--- a/gaff2xml/tests/test_drugs_no_oechem.py
+++ b/gaff2xml/tests/test_drugs_no_oechem.py
@@ -1,21 +1,20 @@
+from nose.plugins.attrib import attr
 from unittest import skipIf
 import tempfile
 import os
 from gaff2xml import utils
 
-def test_drugs():
+def _drug_tester(n_molecules=3404, charge_method="bcc"):
+    """Helper function for running various versions of the drug parameterization benchmark."""
+    assert n_molecules <= 3404, "The maximum number of molecules is 3404."
+    assert charge_method in ["bcc", None], "Charge method must be either None or 'bcc'"
+
     path = tempfile.mkdtemp()
     database_filename = utils.get_data_filename("chemicals/drugs/Zdd.mol2.gz")
     cmd = "gunzip -c %s > %s/Zdd.mol2" % (database_filename, path)
     os.system(cmd)
     cmd = """awk '/MOLECULE/{close(x);x="%s/molecule_"i++".mol2"}{print > x}' %s/Zdd.mol2""" % (path, path)
     os.system(cmd)
-    
-    n_molecules = 3404
-    CHARGE_METHOD = "bcc"
-    if (os.environ.get("TRAVIS", None) == 'true') or (os.environ.get("JENKINS_URL", None) is not None):
-        n_molecules = 25  # If running on travis, only test the first 25 molecules due to speed.
-        CHARGE_METHOD = None  # Travis is actually too slow to do a single bcc calculation!
 
     for k in range(n_molecules):
         molecule_name = "molecule_%d" % k
@@ -24,3 +23,12 @@ def test_drugs():
         os.system(cmd)  # Have to remove the <0> because it leads to invalid XML in the forcefield files.
         with utils.enter_temp_directory():
             yield utils.tag_description(lambda : utils.test_molecule("LIG", mol2_filename, charge_method=CHARGE_METHOD), "Testing drugs %s with charge method %s" % (molecule_name, CHARGE_METHOD))
+
+# This version is too slow to run during the conda-build post-test, on jenkins, or on travis.
+# In fact, Travis is actually too slow to do even a single AM1-BCC calculation
+@attr('slow')
+def test_drugs_all():
+    _drug_tester()
+
+def test_drugs_fast():
+    _drug_tester(n_molecules=20, charge_method=None)

--- a/gaff2xml/tests/test_freesolv.py
+++ b/gaff2xml/tests/test_freesolv.py
@@ -1,3 +1,4 @@
+from nose.plugins.attrib import attr
 from unittest import skipIf
 import tempfile
 import os
@@ -13,19 +14,13 @@ import numpy as np
 
 
 @skipIf(find_executable('obabel') is None, 'You need obabel installed to run this test')
-@skipIf(os.environ.get("TRAVIS", None) == 'true', "Skip testing of entire FreeSolv database on Travis.")
-@skipIf(os.environ.get("JENKINS_URL", None) is not None, "Skip testing of entire FreeSolv database on Jenkins.")
-def test_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb():
+def _tester_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb(charge_method="bcc"):
     with utils.enter_temp_directory():        
         
         tar_filename = utils.get_data_filename("chemicals/freesolv/freesolve_v0.3.tar.bz2")
         tar = tarfile.open(tar_filename, mode="r:bz2")
         tar.extractall()
         tar.close()
-        
-        CHARGE_METHOD = "bcc"
-        if os.environ.get("TRAVIS", None) == 'true':
-            CHARGE_METHOD = None  # Travis is actually too slow to do a single bcc calculation!        
 
         database = pickle.load(open("./v0.3/database.pickle"))
         for key in database:
@@ -38,4 +33,12 @@ def test_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb():
                 t_gaff = md.load(gaff_filename)
 
                 with utils.enter_temp_directory():        
-                     yield utils.tag_description(lambda : utils.test_molecule("LIG", gaff_filename, charge_method=CHARGE_METHOD), "Testing freesolv %s %s with charge model %s" % (directory, key, CHARGE_METHOD))
+                     yield utils.tag_description(lambda : utils.test_molecule("LIG", gaff_filename, charge_method=charge_method), "Testing freesolv %s %s with charge model %s" % (directory, key, charge_method))
+
+@attr("slow")
+def test_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb():
+    _tester_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb()
+
+# Faster version because it skips AM1-BCC
+def test_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb_nobcc():
+    _tester_load_freesolv_gaffmol2_vs_sybylmol2_vs_obabelpdb(charge_method=None)


### PR DESCRIPTION
Key idea: we don't want to hard-code checks for our CI framework (jenkins vs travis) into our nosetests.  So instead, we just be sure to tag things that are slow as slow and skip running those during the conda-build.