### PR TITLE
Edit omega.generate_conformers to resolve #97

### DIFF
--- a/gaff2xml/openeye.py
+++ b/gaff2xml/openeye.py
@@ -154,7 +154,7 @@ def smiles_to_oemol(smiles):
 
     return molecule
 
-def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0, rms_threshold=1.0, stricTypes = False):
+def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0, rms_threshold=1.0, strictTypes = True):
     """Generate conformations for the supplied molecule
 
     Parameters
@@ -165,7 +165,7 @@ def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0
         Max number of conformers to generate.  If None, use default OE Value.
     strictStereo : bool, optional, default=True
         If False, permits smiles strings with unspecified stereochemistry.
-    strictTypes : bool, optional, default=False
+    strictTypes : bool, optional, default=True
         If True, requires that Omega have exact MMFF types for atoms in molecule; otherwise, allows the closest atom type of the same element to be used. 
 
     Returns

--- a/gaff2xml/openeye.py
+++ b/gaff2xml/openeye.py
@@ -154,7 +154,7 @@ def smiles_to_oemol(smiles):
 
     return molecule
 
-def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0, rms_threshold=1.0):
+def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0, rms_threshold=1.0, stricTypes = False):
     """Generate conformations for the supplied molecule
 
     Parameters
@@ -165,6 +165,8 @@ def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0
         Max number of conformers to generate.  If None, use default OE Value.
     strictStereo : bool, optional, default=True
         If False, permits smiles strings with unspecified stereochemistry.
+    strictTypes : bool, optional, default=False
+        If True, requires that Omega have exact MMFF types for atoms in molecule; otherwise, allows the closest atom type of the same element to be used. 
 
     Returns
     -------
@@ -195,14 +197,13 @@ def generate_conformers(molecule, max_confs=800, strictStereo=True, ewindow=15.0
     omega.SetRMSThreshold(rms_threshold)  # Word to the wise: skipping this step can lead to significantly different charges!
     
     omega.SetStrictStereo(strictStereo)
+    omega.SetStrictAtomTypes(strictTypes)
     
-   
     omega.SetIncludeInput(False)  # don't include input
     if max_confs is not None:
         omega.SetMaxConfs(max_confs)
     
     status = omega(molcopy)  # generate conformation
-    
     if not status:
         raise(RuntimeError("omega returned error code %d" % status))
         


### PR DESCRIPTION
Modifying generate_conformers to default to using loose MMFF atom
typing (to allow coverage of a wider range of molecules)